### PR TITLE
chore(security): block merge on high-severity scanner findings

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -288,7 +288,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BLOCK_ON_SEVERITY: critical
+          BLOCK_ON_SEVERITY: high
           SCAN_OK: ${{ steps.validate.outputs.scan_ok }}
           SCAN_REASON: ${{ steps.validate.outputs.reason }}
         run: |
@@ -414,7 +414,7 @@ jobs:
         env:
           # Block when a finding at or above this severity is present.
           # One of: critical | high | medium | low | none. 'none' = advisory only.
-          BLOCK_ON_SEVERITY: critical
+          BLOCK_ON_SEVERITY: high
           SCAN_OK: ${{ steps.validate.outputs.scan_ok }}
           SCAN_REASON: ${{ steps.validate.outputs.reason }}
         run: |


### PR DESCRIPTION
Automated fleet sync of the org security scanner. Raises `BLOCK_ON_SEVERITY` from `critical` to `high` so high and critical findings (and dependency BLOCK) fail the AI security scan check. Medium/low/info remain advisory. See scanner-org for the source template.